### PR TITLE
Reset `TransactionSigner.decode` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ response = contract.send_func(tx: tx, private_key: private_key, method: :transfe
 * supports CITA 0.20 and 0.19
 * set default transaction version to 1
 * update TransactionSinger.decode output type to hash with symbol keys
+* parse TransactionSinger.decode hash value to hex string if it's bytes. 
 
 ## Contributing
 

--- a/lib/appchain/transaction.rb
+++ b/lib/appchain/transaction.rb
@@ -10,7 +10,7 @@ module AppChain
 
     # @param nonce [String] default is SecureRandom.hex; if you provide with nil or empty string, it will be assigned a random string.
     # @param valid_until_block [Integer]
-    # @param chain_id [Integer]
+    # @param chain_id [Integer | String] hex string if version == 1
     # @param version [Integer]
     # @param to [String]
     # @param data [String]
@@ -26,7 +26,11 @@ module AppChain
       @quota = quota
       @valid_until_block = valid_until_block
       @data = data
-      @chain_id = chain_id
+      @chain_id = if chain_id.is_a?(String)
+                    chain_id.delete("-")
+                  else
+                    chain_id
+                  end
       @version = version
       @value = if value.is_a?(Integer)
                  Utils.to_hex(value)

--- a/lib/appchain/utils.rb
+++ b/lib/appchain/utils.rb
@@ -15,6 +15,15 @@ module AppChain
         HEX_PREFIX + hex
       end
 
+      # add `0x` prefix to not blank hex string
+      #
+      # @param hex [String]
+      def add_prefix_for_not_blank(hex)
+        return add_hex_prefix(hex) unless hex.blank?
+
+        hex
+      end
+
       # remove `0x` prefix from hex string
       #
       # @param hex [String]
@@ -55,7 +64,10 @@ module AppChain
       # @param bytes_str [String] byte code string
       # @return [String] normal string
       def from_bytes(bytes_str)
-        AppChain::Utils.add_hex_prefix(bytes_str.unpack1("H*"))
+        hex = bytes_str.unpack1("H*")
+        return AppChain::Utils.add_hex_prefix(hex) unless hex.blank?
+
+        hex
       end
 
       # keccak 256 hash

--- a/spec/appchain/transaction_signer_spec.rb
+++ b/spec/appchain/transaction_signer_spec.rb
@@ -82,15 +82,24 @@ RSpec.describe AppChain::TransactionSigner do
       }
     end
 
-    it "correct" do
-      data = AppChain::TransactionSigner.decode(content)
+    it "original decode" do
+      data = AppChain::TransactionSigner.original_decode(content)
 
       expect(data[:unverified_transaction][:transaction]).to eq expect_data[:unverified_transaction][:transaction]
       expect(data[:unverified_transaction][:crypto]).to eq expect_data[:unverified_transaction][:crypto]
       expect(data[:sender]).to eq expect_data[:sender]
     end
 
+    it "decode" do
+      output = AppChain::TransactionSigner.decode(content)
+      utx = output[:unverified_transaction]
+      tx = utx[:transaction]
 
+      expect(tx[:to]).to eq ""
+      expect(tx[:data]).to eq "0x#{data}"
+      expect(tx[:value]).to eq "0x#{expect_data[:unverified_transaction][:transaction][:value].unpack1("H*")}"
+      expect(utx[:signature]).to eq "0x#{expect_data[:unverified_transaction][:signature].unpack1("H*")}"
+    end
   end
 
 
@@ -172,12 +181,23 @@ RSpec.describe AppChain::TransactionSigner do
           }
         end
 
-        it "correct" do
-          data = AppChain::TransactionSigner.decode(content)
+        it "original decode" do
+          data = AppChain::TransactionSigner.original_decode(content)
 
           expect(data[:unverified_transaction][:transaction].to_h).to eq expected_data[:unverified_transaction][:transaction]
           expect(data[:unverified_transaction][:crypto]).to eq expected_data[:unverified_transaction][:crypto]
           expect(data[:sender]).to eq expected_data[:sender]
+        end
+
+        it "decode" do
+          output = AppChain::TransactionSigner.decode(content)
+          utx = output[:unverified_transaction]
+          tx = utx[:transaction]
+
+          expect(tx[:to]).to eq "0x#{expected_data[:unverified_transaction][:transaction][:to]}"
+          expect(tx[:data]).to eq ""
+          expect(tx[:value]).to eq "0x#{expected_data[:unverified_transaction][:transaction][:value].unpack1("H*")}"
+          expect(utx[:signature]).to eq "0x#{expected_data[:unverified_transaction][:signature].unpack1("H*")}"
         end
       end
 
@@ -207,12 +227,23 @@ RSpec.describe AppChain::TransactionSigner do
           }
         end
 
-        it "success" do
-          data = AppChain::TransactionSigner.decode(content)
+        it "original decode" do
+          data = AppChain::TransactionSigner.original_decode(content)
 
           expect(data[:unverified_transaction][:transaction].to_h).to eq expected_data[:unverified_transaction][:transaction]
           expect(data[:unverified_transaction][:crypto]).to eq expected_data[:unverified_transaction][:crypto]
           expect(data[:sender]).to eq expected_data[:sender]
+        end
+
+        it "decode" do
+          output = AppChain::TransactionSigner.decode(content)
+          utx = output[:unverified_transaction]
+          tx = utx[:transaction]
+
+          expect(tx[:to]).to eq "0x#{expected_data[:unverified_transaction][:transaction][:to].unpack1("H*")}"
+          expect(tx[:data]).to eq ""
+          expect(tx[:value]).to eq "0x#{expected_data[:unverified_transaction][:transaction][:value].unpack1("H*")}"
+          expect(utx[:signature]).to eq "0x#{expected_data[:unverified_transaction][:signature].unpack1("H*")}"
         end
       end
     end

--- a/spec/appchain/transaction_spec.rb
+++ b/spec/appchain/transaction_spec.rb
@@ -19,4 +19,27 @@ RSpec.describe AppChain::Transaction do
       expect(transaction.nonce).to eq nonce
     end
   end
+
+  context "chain_id" do
+    let(:nonce) { "" }
+
+    it "get itself if integer" do
+      chain_id = 1
+      transaction = AppChain::Transaction.new(valid_until_block: valid_until_block, nonce: nonce, chain_id: chain_id)
+      expect(transaction.chain_id).to eq chain_id
+    end
+
+    it "get it self if a hex string" do
+      chain_id = SecureRandom.hex
+      transaction = AppChain::Transaction.new(valid_until_block: valid_until_block, nonce: nonce, chain_id: chain_id)
+      expect(transaction.chain_id).to eq chain_id
+    end
+
+    it "remove - if exists" do
+      chain_id = SecureRandom.uuid
+      transaction = AppChain::Transaction.new(valid_until_block: valid_until_block, nonce: nonce, chain_id: chain_id)
+      expect(transaction.chain_id).not_to eq chain_id
+      expect(transaction.chain_id).to eq chain_id.remove("-")
+    end
+  end
 end


### PR DESCRIPTION
1. Reset `TransactionSigner.decode` output, parse bytes to hex string, named old `decode` method to `original_decode`
2. Support uuid in chain_id